### PR TITLE
Show and count also servers with policy 'approve'

### DIFF
--- a/src/classes/Controllers/Web/Servers.php
+++ b/src/classes/Controllers/Web/Servers.php
@@ -62,7 +62,7 @@ class Servers extends BaseController
 
 		$stmt = 'SELECT *
 FROM `server` s
-WHERE `reg_policy` = "REGISTER_OPEN"
+WHERE `reg_policy` != "REGISTER_CLOSED"
 AND `available`
 AND NOT `hidden`
 ORDER BY `health_score` DESC, `ssl_state` DESC, `info` != "" DESC, `last_seen` DESC
@@ -81,7 +81,7 @@ LIMIT :start, :limit';
 
 		$stmt = 'SELECT COUNT(*)
 FROM `server` s
-WHERE `reg_policy` = "REGISTER_OPEN"
+WHERE `reg_policy` != "REGISTER_CLOSED"
 AND `available`
 AND NOT `hidden`';
 		$count = $this->atlas->fetchValue($stmt);

--- a/src/classes/Controllers/Web/Statistics.php
+++ b/src/classes/Controllers/Web/Statistics.php
@@ -74,7 +74,7 @@ class Statistics extends BaseController
 				COUNT(*) AS `total`,
 				SUM(CASE WHEN `available` THEN 1 ELSE 0 END) AS `available`,
 				SUM(CASE WHEN `available` AND `language` IS NOT NULL THEN 1 ELSE 0 END) AS `language`,
-				SUM(CASE WHEN `available` AND `reg_policy` = "REGISTER_OPEN" THEN 1 ELSE 0 END) AS `open`,
+				SUM(CASE WHEN `available` AND `reg_policy` != "REGISTER_CLOSED" THEN 1 ELSE 0 END) AS `open`,
 				SUM(CASE WHEN `available` AND `version` IS NOT NULL THEN 1 ELSE 0 END) AS `version`,
 				SUM(CASE WHEN `available` AND (`version` = :dev_version OR `version` = :rc_version) THEN 1 ELSE 0 END) AS `dev_version`,
 				SUM(CASE WHEN `available` AND `version` = :stable_version THEN 1 ELSE 0 END) AS `stable_version`,


### PR DESCRIPTION
Changed the queries to show and count also servers with register policy 'approval'.